### PR TITLE
Fix OneTrust second layer

### DIFF
--- a/packages/react-native-contentpass-cmp-onetrust/package.json
+++ b/packages/react-native-contentpass-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentpass/react-native-contentpass-cmp-onetrust",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Contentpass OneTrust CMP adapter",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/packages/react-native-contentpass-cmp-onetrust/src/OnetrustCmpAdapter.ts
+++ b/packages/react-native-contentpass-cmp-onetrust/src/OnetrustCmpAdapter.ts
@@ -100,11 +100,7 @@ export default class OnetrustCmpAdapter implements CmpAdapter {
         }
       });
 
-      if (view === 'vendor') {
-        this.sdk.showPreferenceCenterUI();
-      } else {
-        this.sdk.showConsentPurposesUI();
-      }
+      this.sdk.showPreferenceCenterUI();
     });
   }
 


### PR DESCRIPTION
This fixes the OneTrust integration part for opening the OneTrust preference center. Before, we accidentally tried to open the (Universal Consent Purposes UI (UCP) which was not available.