### PR TITLE
fix: hide children during login / second layer

### DIFF
--- a/packages/react-native-contentpass-ui/CHANGELOG.md
+++ b/packages/react-native-contentpass-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @contentpass/react-native-contentpass-ui
 
+## 0.3.1
+
+### Patch Changes
+
+- Fix loading state during login
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/react-native-contentpass-ui/package.json
+++ b/packages/react-native-contentpass-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentpass/react-native-contentpass-ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Contentpass React Native UI Components",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/react-native-contentpass-ui/src/components/ContentpassConsentGate.tsx
+++ b/packages/react-native-contentpass-ui/src/components/ContentpassConsentGate.tsx
@@ -148,7 +148,7 @@ export default function ContentpassConsentGate({
     onVisibilityChange,
   ]);
 
-  if (!consentResolved) {
+  if (!consentResolved || isShowingContentpass || isShowingSecondLayer) {
     return (
       <View style={styles.loading}>
         <ActivityIndicator size="large" />


### PR DESCRIPTION
When second layer is show, or contentpass login popup is open, we should not show the App's children.