### PR TITLE
Allow passing preferred layer language

### DIFF
--- a/packages/react-native-contentpass-ui/CHANGELOG.md
+++ b/packages/react-native-contentpass-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @contentpass/react-native-contentpass-ui
 
+## 0.4.0
+
+### Minor Changes
+
+- Allow defining preferred layer language
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/react-native-contentpass-ui/README.md
+++ b/packages/react-native-contentpass-ui/README.md
@@ -35,6 +35,7 @@ A gate component that wraps your app content. It automatically shows the Content
 | `cmpAdapter` | `CmpAdapter` | Yes | — | A CMP adapter instance (e.g. from `@contentpass/react-native-contentpass-cmp-onetrust`). |
 | `contentpassConfig` | `ContentpassConfig` | Yes | — | The Contentpass SDK configuration object. |
 | `hideAppWhenVisible` | `boolean` | No | `true` | When `true`, the app content is completely replaced by the consent layer. When `false`, the consent layer is rendered as an overlay on top of the app content. |
+| `locale` | `string` | No | — | Forces the consent layer to be displayed in the given locale (e.g. `"de"`, `"es"`). When omitted, the layer picks the locale from the user's browser/device preferences and falls back to English. Unsupported values are ignored by the layer. |
 | `onVisibilityChange` | `(visible: boolean) => void` | No | — | Callback invoked when the consent layer visibility changes. |
 
 ## Usage

--- a/packages/react-native-contentpass-ui/package.json
+++ b/packages/react-native-contentpass-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentpass/react-native-contentpass-ui",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Contentpass React Native UI Components",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/react-native-contentpass-ui/src/components/ContentpassConsentGate.tsx
+++ b/packages/react-native-contentpass-ui/src/components/ContentpassConsentGate.tsx
@@ -17,6 +17,7 @@ type ContentpassConsentGateProps = {
   cmpAdapter: CmpAdapter;
   contentpassConfig: ContentpassConfig;
   hideAppWhenVisible?: boolean;
+  locale?: string;
   onVisibilityChange?: (visible: boolean) => void;
 };
 
@@ -25,6 +26,7 @@ export default function ContentpassConsentGate({
   cmpAdapter,
   contentpassConfig,
   hideAppWhenVisible = true,
+  locale,
   onVisibilityChange,
 }: ContentpassConsentGateProps) {
   const sdk = useContentpassSdk();
@@ -170,6 +172,7 @@ export default function ContentpassConsentGate({
         propertyId={contentpassConfig.propertyId}
         purposesList={purposesList}
         vendorCount={vendorCount}
+        locale={locale}
       />
     );
   }

--- a/packages/react-native-contentpass-ui/src/components/ContentpassLayer.tsx
+++ b/packages/react-native-contentpass-ui/src/components/ContentpassLayer.tsx
@@ -93,6 +93,7 @@ export default function ContentpassLayer({
   propertyId,
   purposesList,
   vendorCount,
+  locale,
 }: {
   baseUrl: string;
   eventHandler: ContentpassLayerEvents;
@@ -101,6 +102,7 @@ export default function ContentpassLayer({
   propertyId: string;
   purposesList: string[];
   vendorCount: number;
+  locale?: string;
 }) {
   const firstLayerUrl = useMemo(() => {
     return buildFirstLayerUrl({
@@ -109,8 +111,9 @@ export default function ContentpassLayer({
       planId,
       purposesList,
       vendorCount,
+      locale,
     });
-  }, [baseUrl, planId, propertyId, purposesList, vendorCount]);
+  }, [baseUrl, planId, propertyId, purposesList, vendorCount, locale]);
 
   const [ready, setReady] = useState(false);
   const [popupUrl, setPopupUrl] = useState<string | null>(null);

--- a/packages/react-native-contentpass-ui/src/components/buildFirstLayerUrl.test.ts
+++ b/packages/react-native-contentpass-ui/src/components/buildFirstLayerUrl.test.ts
@@ -40,11 +40,25 @@ describe('buildFirstLayerUrl', () => {
     );
   });
 
-  it('should set locale to en-US', () => {
+  it('should omit the locale parameter when no locale is provided', () => {
     const url = buildFirstLayerUrl(defaultParams);
     const parsed = new URL(url);
 
-    expect(parsed.searchParams.get('locale')).toBe('en-US');
+    expect(parsed.searchParams.has('locale')).toBe(false);
+  });
+
+  it('should include the locale parameter when provided', () => {
+    const url = buildFirstLayerUrl({ ...defaultParams, locale: 'es' });
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get('locale')).toBe('es');
+  });
+
+  it('should omit the locale parameter when an empty string is provided', () => {
+    const url = buildFirstLayerUrl({ ...defaultParams, locale: '' });
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.has('locale')).toBe(false);
   });
 
   it('should include the planId parameter', () => {

--- a/packages/react-native-contentpass-ui/src/components/buildFirstLayerUrl.ts
+++ b/packages/react-native-contentpass-ui/src/components/buildFirstLayerUrl.ts
@@ -10,19 +10,23 @@ export default function buildFirstLayerUrl({
   planId,
   purposesList,
   vendorCount,
+  locale,
 }: {
   baseUrl: string;
   propertyId: string;
   planId: string;
   purposesList: string[];
   vendorCount: number;
+  locale?: string;
 }): string {
   // FIXME handle trailing slash in baseUrl
   const url = new URL(`${baseUrl}/first-layer/`);
   url.searchParams.set('start', 'true');
   url.searchParams.set('theme', THEME);
   url.searchParams.set('v', SDK_VERSION);
-  url.searchParams.set('locale', 'en-US');
+  if (locale) {
+    url.searchParams.set('locale', locale);
+  }
   url.searchParams.set('planId', planId);
   url.searchParams.set('propertyId', propertyId);
   url.searchParams.set('purposesList', purposesList.join(','));


### PR DESCRIPTION
This allows the App to pass the preferred locale the consent layer should be displayed in (e.g. if the app allow switching languages in their settings). The parameter is optional and will fall back to the systems preferred locale.